### PR TITLE
Prepare v1.1.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## v1.1.0 - July 17, 2024
+
+### Added
+
+* Add offset property to `RpcMethod`
+* Add offset property to `SecurityCallback`
+
+### Changed
+
+* Fix type errors caused by newer v versions
+* Fix incorrect attr syntax in newer v versions
+* Fix incorrect address of security callbacks
+* Rename `base` property of `RpcMethod` to `addr`
+* Rename `base` property of `SecurityCallback` to `addr`
+
+
 ## v1.0.1 - Sep 24, 2023
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![](https://github.com/qtc-de/rpv/actions/workflows/build-examples.yml/badge.svg?branch=main)](https://github.com/qtc-de/rpv/actions/workflows/build-examples.yml)
 [![](https://github.com/qtc-de/rpv/actions/workflows/build-examples.yml/badge.svg?branch=dev)](https://github.com/qtc-de/rpv/actions/workflows/build-examples.yml)
-[![](https://img.shields.io/badge/version-1.0.1-blue)](https://github.com/qtc-de/rpv/releases)
+[![](https://img.shields.io/badge/version-1.1.0-blue)](https://github.com/qtc-de/rpv/releases)
 [![](https://img.shields.io/badge/programming%20language-v-blue)](https://vlang.io/)
 [![](https://img.shields.io/badge/license-GPL%20v3.0-blue)](https://github.com/qtc-de/rpv/blob/master/LICENSE)
 [![](https://img.shields.io/badge/docs-fa6b05)](https://qtc-de.github.io/rpv)
@@ -29,7 +29,7 @@ Assuming that *v* [is installed](https://github.com/vlang/v#installing-v-from-so
 installing *rpv* can be done using the following command:
 
 ```console
-[user@host ~]$ v install qtc_de.rpv
+[user@host ~]$ v install qtc-de.rpv
 ```
 
 After installation, *rpv* can be used to analyze *RPC* servers and

--- a/alternate/default-x64.v
+++ b/alternate/default-x64.v
@@ -82,7 +82,7 @@ pub const compatible_rpc_versions = [
 // of v, the '[if x64]' attribute is ignored for structs, but will be
 // available in future. Up to this point, we need to keep the x64 and x86
 // struct definitions in separate files.
-[if x64]
+@[if x64]
 pub struct RpcInterface {
 pub:
 	p_rpc_server                  &RpcServer = unsafe { nil }
@@ -123,7 +123,7 @@ pub:
 // of v, the '[if x64]' attribute is ignored for structs, but will be
 // available in future. Up to this point, we need to keep the x64 and x86
 // struct definitions in separate files.
-[if x64]
+@[if x64]
 pub struct RpcServer {
 pub:
 	mutex                   Mutex
@@ -167,7 +167,7 @@ pub:
 // of v, the '[if x64]' attribute is ignored for structs, but will be
 // available in future. Up to this point, we need to keep the x64 and x86
 // struct definitions in separate files.
-[if x64]
+@[if x64]
 pub struct RpcAddress {
 pub:
 	vtable       voidptr

--- a/alternate/default-x86.v
+++ b/alternate/default-x86.v
@@ -82,7 +82,7 @@ pub const compatible_rpc_versions = [
 // of v, the '[if x86]' attribute is ignored for structs, but will be
 // available in future. Up to this point, we need to keep the x64 and x86
 // struct definitions in separate files.
-[if x86]
+@[if x86]
 pub struct RpcInterface {
 pub:
 	p_rpc_server                  &RpcServer = unsafe { nil }
@@ -119,7 +119,7 @@ pub:
 // of v, the '[if x86]' attribute is ignored for structs, but will be
 // available in future. Up to this point, we need to keep the x64 and x86
 // struct definitions in separate files.
-[if x86]
+@[if x86]
 pub struct RpcServer {
 pub:
 	mutex                   Mutex
@@ -158,7 +158,7 @@ pub:
 // of v, the '[if x86]' attribute is ignored for structs, but will be
 // available in future. Up to this point, we need to keep the x64 and x86
 // struct definitions in separate files.
-[if x86]
+@[if x86]
 pub struct RpcAddress {
 pub:
 	vtable       voidptr

--- a/examples/details.v
+++ b/examples/details.v
@@ -54,14 +54,15 @@ fn main()
 
 				println('[+] Security Callback:')
 
-				if intf.sec_callback.base != 0
+				if intf.sec_callback.addr != 0
 				{
 					println('[+]\t Registred   : True')
-					println('[+]\t Base Address: 0x${intf.sec_callback.base}')
+					println('[+]\t Address     : 0x${intf.sec_callback.addr}')
+					println('[+]\t Offset      : 0x${intf.sec_callback.offset.hex()}')
 
 					if intf.sec_callback.location.path != ''
 					{
-						println('[+]\t Location    : 0x${intf.sec_callback.location.path}')
+						println('[+]\t Location    : ${intf.sec_callback.location.path}')
 					}
 				}
 
@@ -74,7 +75,7 @@ fn main()
 
 				for method in intf.methods
 				{
-					println('[+]\t ${method.name} (base: 0x${method.base})')
+					println('[+]\t ${method.name} (addr: 0x${method.addr}, offset: 0x${method.offset.hex()})')
 				}
 
 				return

--- a/examples/list.v
+++ b/examples/list.v
@@ -25,12 +25,14 @@ fn main()
 		println('[+] Path        : ${info.path}')
 
 		println('[+] RPC Endpoints:')
+
 		for endpoint in info.rpc_info.server_info.endpoints
 		{
 			println('[+]\t ${endpoint.protocol} - ${endpoint.name}')
 		}
 
 		println('[+] RPC Interfaces:')
+
 		for intf in info.rpc_info.interface_infos
 		{
 			if intf.methods.len > 0

--- a/internals/rpc-common.v
+++ b/internals/rpc-common.v
@@ -86,7 +86,7 @@ pub:
 
 // C.RPC_IF_ID represents an ID of an RPC interface. This is basically an GUID
 // but also contains a major and minor version.
-[typedef]
+@[typedef]
 pub struct C.RPC_IF_ID {
 	Uuid      C.GUID
 	VersMajor u16
@@ -103,7 +103,7 @@ pub fn (this C.RPC_IF_ID) equals(other C.RPC_IF_ID) bool
 // C.RPC_DISPATCH_TABLE contains information on the defined RPC methods of an
 // RPC interface. rpv uses it to determine the method count, that can be obtained
 // from the DispatchTableCount property.
-[typedef]
+@[typedef]
 pub struct C.RPC_DISPATCH_TABLE {
 	DispatchTableCount u32
 	DispatchTable      voidptr
@@ -116,7 +116,7 @@ pub struct C.RPC_DISPATCH_TABLE {
 // formatting of these methods. This is used in conjunction with the FmtStringOffset
 // property, which contains the offset of the different methods within the ProcString,
 // to decompile RPC methods.
-[typedef]
+@[typedef]
 pub struct C.MIDL_SERVER_INFO {
 	pStubDesc       &C.MIDL_STUB_DESC = unsafe { nil }
 	DispatchTable   &voidptr     = unsafe { nil }
@@ -133,7 +133,7 @@ pub struct C.MIDL_SERVER_INFO {
 // by the RPC methods of the corresponding interface. rpv uses this information to decompile
 // RPC methods. Moreover, Reserved5 is required for parsing NDR expressions. Actually the
 // member is named pExprInfo by Microsoft, but within the mingw libraries it is Reserved5.
-[typedef]
+@[typedef]
 pub struct C.MIDL_STUB_DESC {
 	RpcInterfaceInformation     voidptr = unsafe { nil }
 	pfnAllocate                 voidptr = unsafe { nil }
@@ -173,7 +173,7 @@ pub struct NDR_EXPR_DESC {
 
 // C.MIDL_SYNTAX_INFO is a struct that is used within internal RPC struct definitions.
 // It is currently not used by rpv.
-[typedef]
+@[typedef]
 pub struct C.MIDL_SYNTAX_INFO {
 	TransferSyntax        C.RPC_SYNTAX_IDENTIFIER
 	DispatchTable         &C.RPC_DISPATCH_TABLE
@@ -186,7 +186,7 @@ pub struct C.MIDL_SYNTAX_INFO {
 
 // C.MIDL_INTERFACE_METHOD_PROPERTIES is a struct that is used within internal RPC struct definitions.
 // It is currently not used by rpv.
-[typedef]
+@[typedef]
 pub struct C.MIDL_INTERFACE_METHOD_PROPERTIES {
 	MethodCount      u16
 	MethodProperties &C.MIDL_METHOD_PROPERTY_MAP
@@ -194,7 +194,7 @@ pub struct C.MIDL_INTERFACE_METHOD_PROPERTIES {
 
 // C.MIDL_METHOD_PROPERTY_MAP is a struct that is used within internal RPC struct definitions.
 // It is currently not used by rpv.
-[typedef]
+@[typedef]
 pub struct C.MIDL_METHOD_PROPERTY_MAP {
 	count      u32
 	Properties &C.MIDL_METHOD_PROPERTY
@@ -202,7 +202,7 @@ pub struct C.MIDL_METHOD_PROPERTY_MAP {
 
 // C.MIDL_METHOD_PROPERTY is a struct that is used within internal RPC struct definitions.
 // It is currently not used by rpv.
-[typedef]
+@[typedef]
 pub struct C.MIDL_METHOD_PROPERTY {
 	Id    u32
 	value usize
@@ -210,7 +210,7 @@ pub struct C.MIDL_METHOD_PROPERTY {
 
 // C.UUID_VECTOR is a struct that is used within internal RPC struct definitions.
 // It is currently not used by rpv.
-[typedef]
+@[typedef]
 pub struct C.UUID_VECTOR {
 	Count u32
 	Uuid  [1]&C.GUID
@@ -218,7 +218,7 @@ pub struct C.UUID_VECTOR {
 
 // C.RPC_SYNTAX_IDENTIFIER is a struct that is used within internal RPC struct definitions.
 // It is currently not used by rpv.
-[typedef]
+@[typedef]
 pub struct C.RPC_SYNTAX_IDENTIFIER {
 	SyntaxGUID    C.GUID
 	SyntaxVersion C.RPC_VERSION
@@ -226,7 +226,7 @@ pub struct C.RPC_SYNTAX_IDENTIFIER {
 
 // C.RPC_VERSION is a struct that is used within internal RPC struct definitions.
 // It is currently not used by rpv.
-[typedef]
+@[typedef]
 pub struct C.RPC_VERSION {
 	MajorVersion u16
 	MinorVersion u16

--- a/internals/rpc-common.v
+++ b/internals/rpc-common.v
@@ -151,13 +151,13 @@ pub struct C.MIDL_STUB_DESC {
 	MIDLVersion       u32
 	CommFaultOffsets  &C.COMM_FAULT_OFFSETS = unsafe { nil }
 	// New fields for version 3.0+
-	aUserMarshalQuadruple &C.USER_MARSHAL_ROUTINE_QUADRUPLE = unsafe { nil }
+	aUserMarshalQuadruple voidptr = unsafe { nil }
 	// Notify routines - added for NT5, MIDL 5.0
-	NotifyRoutineTable &C.NDR_NOTIFY_ROUTINE = unsafe { nil }
+	NotifyRoutineTable voidptr = unsafe { nil }
 	// Reserved for future use.
 	mFlags &u32 = unsafe { nil }
 	// International support routines - added for 64bit post NT5
-	CsRoutineTables &C.NDR_CS_ROUTINES = unsafe { nil }
+	CsRoutineTables voidptr = unsafe { nil }
 	Reserved4       voidptr = unsafe { nil }
 	Reserved5       voidptr = unsafe { nil } // mIDA: expr_table - RpcView: pExprInfo
 	// Fields up to now present in win2000 release.

--- a/internals/rpc-internal-structs.v
+++ b/internals/rpc-internal-structs.v
@@ -82,7 +82,7 @@ pub const compatible_rpc_versions = [
 // of v, the '[if x64]' attribute is ignored for structs, but will be
 // available in future. Up to this point, we need to keep the x64 and x86
 // struct definitions in separate files.
-[if x64]
+@[if x64]
 pub struct RpcInterface {
 pub:
 	p_rpc_server                  &RpcServer = unsafe { nil }
@@ -123,7 +123,7 @@ pub:
 // of v, the '[if x64]' attribute is ignored for structs, but will be
 // available in future. Up to this point, we need to keep the x64 and x86
 // struct definitions in separate files.
-[if x64]
+@[if x64]
 pub struct RpcServer {
 pub:
 	mutex                   Mutex
@@ -167,7 +167,7 @@ pub:
 // of v, the '[if x64]' attribute is ignored for structs, but will be
 // available in future. Up to this point, we need to keep the x64 and x86
 // struct definitions in separate files.
-[if x64]
+@[if x64]
 pub struct RpcAddress {
 pub:
 	vtable       voidptr

--- a/ndr/context.v
+++ b/ndr/context.v
@@ -17,6 +17,19 @@ pub struct NdrContext {
 	type_cache &TypeCache
 }
 
+// newNdrContext creates a new NdrContext. The main reason why we have a constructor
+// here is to leave the struct fields access modifiers untouched. In newer v releases,
+// initializing private struct fields seems only possible using a constructor.
+pub fn NdrContext.new(handle win.HANDLE, stub_desc C.MIDL_STUB_DESC, flags NdrInterpreterOptFlags2, mut cache &TypeCache) NdrContext
+{
+	return NdrContext {
+		process_handle: handle
+		stub_desc: stub_desc
+		flags: flags
+		type_cache: cache
+	}
+}
+
 // read attempts to read the type <T> from process memory at the specified
 // address. If successfully, a newly created <T> type is returned. How many
 // bytes to read is determined by the structure size of <T>. Notice that

--- a/ndr/flags.v
+++ b/ndr/flags.v
@@ -3,7 +3,7 @@ module ndr
 // NdrFlags contains additional information for NDR data.
 // Especially the has_return value is important for rpv,
 // as it indicates whether a method returns a value.
-[flag]
+@[flag]
 pub enum NdrFlags as u8
 {
 	server_must_size
@@ -19,7 +19,7 @@ pub enum NdrFlags as u8
 // NdrInterpreterOptFlags2 contains additional information
 // on how to interpret NDR data. rpv needs this struct to
 // determine how specific NDR types need to be parsed.
-[flag]
+@[flag]
 pub enum NdrInterpreterOptFlags2 as u8
 {
 	has_new_corr_desc

--- a/ndr/ndr_basic.v
+++ b/ndr/ndr_basic.v
@@ -283,6 +283,14 @@ pub struct NdrSimpleType {
 	NdrBaseType
 }
 
+// new creates a new instance of NdrSimpleType. A constructor for this type was
+// defined, because it is also initialized from other modules which are not able
+// to access the private format property.
+pub fn NdrSimpleType.new(format NdrFormatChar) NdrSimpleType
+{
+	return NdrSimpleType { format: format }
+}
+
 // format returns the string representation of NdrSimpleType. This is always the
 // same as the result of calling the format method on the underlying NdrBaseType.
 pub fn (simple_type NdrSimpleType) format() string

--- a/ndr/ndr_correlation.v
+++ b/ndr/ndr_correlation.v
@@ -28,7 +28,7 @@ pub enum NdrCorrelationType as u8
 // NdrCorrelationFlags provide additional information on a CorrelationDescriptor.
 // As far as I remember, only the range member of this enum is currently used and
 // implemented by rpv.
-[flag]
+@[flag]
 pub enum NdrCorrelationFlags as u8
 {
 	reserved

--- a/ndr/ndr_param.v
+++ b/ndr/ndr_param.v
@@ -8,7 +8,7 @@ module ndr
 // NdrHandleParam and to define a separate format method for both
 // types. However, this caused nondeterministic memory corruptions.
 // We may try this approach in future again.
-[flag]
+@[flag]
 pub enum NdrParamAttrs as u16
 {
 	must_size
@@ -103,7 +103,7 @@ pub fn (param NdrBasicParam) comments() []NdrComment
 // NdrHandleParamFlags contains a list of flags that can be
 // used in NdrHandleParam. These flags add more information
 // to the underlying handle.
-[flag]
+@[flag]
 pub enum NdrHandleParamFlags as u8
 {
 	ndr_context_handle_cannot_be_null

--- a/ndr/ndr_pointer.v
+++ b/ndr/ndr_pointer.v
@@ -29,6 +29,18 @@ pub struct NdrPointer {
 	flags NdrPointerFlags
 }
 
+// new creates a new instance of NdrPointer. A constructor for this type was
+// defined, because it is also initialized from other modules which are not able
+// to access the private format property.
+pub fn NdrPointer.new(format NdrFormatChar, ref NdrType, flags NdrPointerFlags) NdrPointer
+{
+	return NdrPointer {
+		format: format
+		ref: ref
+		flags: flags
+	}
+}
+
 // attrs returns an array of NdrAttr that is associated to the
 // NdrPointer type. This includes attributes that are associated
 // to the pointer itself, as well as attributes that are associated

--- a/ndr/ndr_pointer.v
+++ b/ndr/ndr_pointer.v
@@ -6,7 +6,7 @@ import internals
 // NdrPointerFlags contains a list of flags that can be set for
 // NdrPointer types. These flags add additional information to
 // the pointer that can be used during parsing and formatting.
-[flag]
+@[flag]
 pub enum NdrPointerFlags as u8
 {
 	fc_allocate_all_nodes

--- a/ndr/type_cache.v
+++ b/ndr/type_cache.v
@@ -24,6 +24,7 @@ interface ComplexType {
 // decompilation, the types member contains all complex types that have
 // been encountered within an interface. This allows easy formatting of
 // decompilation results.
+@[heap]
 pub struct TypeCache {
 	mut:
 	type_map map[string]NdrType

--- a/src/midl.v
+++ b/src/midl.v
@@ -259,7 +259,7 @@ pub fn (intf RpcInterfaceInfo) decode_method(process_handle win.HANDLE, index in
 			context_type := win.read_proc_mem[u8](process_handle, mut &ptr)!
 			context_flags := win.read_proc_mem[ndr.NdrHandleParamFlags](process_handle, mut &ptr)!
 			handle_offset := win.read_proc_mem[u16](process_handle, mut &ptr)!
-			param_type := ndr.NdrType(ndr.NdrSimpleType { format: ndr.NdrFormatChar(context_type) })
+			param_type := ndr.NdrType(ndr.NdrSimpleType.new(ndr.NdrFormatChar(context_type)))
 
 			utils.log_debug('Function bind type is 0x${context_type.hex()}')
 
@@ -288,11 +288,7 @@ pub fn (intf RpcInterfaceInfo) decode_method(process_handle win.HANDLE, index in
 
 			if context_flags.has(.handle_param_is_via_ptr)
 			{
-				param_type = ndr.NdrPointer{
-					format: ndr.NdrFormatChar.fc_pointer
-					ref: param_type
-					flags: ndr.NdrPointerFlags.fc_simple_pointer
-				}
+				param_type = ndr.NdrPointer.new(ndr.NdrFormatChar.fc_pointer, param_type, ndr.NdrPointerFlags.fc_simple_pointer)
 			}
 
 			handle = ndr.NdrHandleParam {
@@ -314,7 +310,7 @@ pub fn (intf RpcInterfaceInfo) decode_method(process_handle win.HANDLE, index in
 				NdrBasicParam: ndr.NdrBasicParam {
 					name: 'binding'
 					attrs: .is_binding
-					typ: ndr.NdrSimpleType{ format: ndr.NdrFormatChar(handle_type) }
+					typ: ndr.NdrSimpleType.new(ndr.NdrFormatChar(handle_type))
 					offset: 0
 				}
 				flags: ndr.NdrHandleParamFlags(0)
@@ -352,12 +348,7 @@ pub fn (intf RpcInterfaceInfo) decode_method(process_handle win.HANDLE, index in
 			}
 		}
 
-		context := ndr.NdrContext {
-			process_handle: process_handle
-			stub_desc: intf.midl_stub_desc
-			flags: header_exts.flags
-			type_cache: type_cache
-		}
+		context := ndr.NdrContext.new(process_handle, intf.midl_stub_desc, header_exts.flags, mut type_cache)
 
 		param_list := []ndr.NdrBasicParam{cap: int(arg_num) + 1}
 		utils.log_debug('Parsing ${arg_num} procedure parameters at ${voidptr(intf.midl_stub_desc.pFormatTypes)}.')

--- a/src/midl.v
+++ b/src/midl.v
@@ -377,7 +377,7 @@ pub fn (intf RpcInterfaceInfo) decode_method(process_handle win.HANDLE, index in
 
 		mut midl_function := MidlFunction {
 			name: method.name
-			offset: method.base
+			offset: method.addr
 			opcode: index
 			arg_num: arg_num
 			arg_offset: usize(ptr)

--- a/utils/utils.v
+++ b/utils/utils.v
@@ -2,7 +2,7 @@ module utils
 
 // log_debug logs the specified message to stderr. It is only used
 // if rpv was compiled with the debug flag.
-[if debug]
+@[if debug]
 pub fn log_debug[T](msg T) {
 	eprintln('[DEBUG] ${msg}')
 }

--- a/v.mod
+++ b/v.mod
@@ -2,7 +2,7 @@ Module
 {
     name: 'rpv'
     author: 'Tobias Neitzel (@qtc_de)'
-    version: '1.0.1'
+    version: '1.1.0'
     repo_url: 'https://github.com/qtc-de/rpv'
     vcs: 'git'
     tags: ['rpc', 'rpv', 'rpv-web', 'rpcview']

--- a/win/interop.v
+++ b/win/interop.v
@@ -63,6 +63,8 @@ type REGSAM = int
 type SIZE_T = u32
 type ULONGLONG = u64
 type PCSTR = &char
+type NTSTATUS = u32
+type KPRIORITY = u32
 
 // Arch represents an CPU architecture. Architectures can be x86
 // x64 or are unknown.
@@ -152,6 +154,16 @@ pub enum SID_NAME_USE {
 // here to get access to it.
 pub struct PS_PROTECTION {
 	level u8
+}
+
+// C.RGBQUAD represents the well known RGBQUAD struct from widows. In rpv
+// it is not used, but definition is required for C interop.
+[typedef]
+pub struct C.RGBQUAD {
+	rgbBlue		BYTE
+	rgbGreen	BYTE
+	rgbRed		BYTE
+	rgbReserved	BYTE
 }
 
 // C.GUID represents the well known GUID struct from widows. In rpv,
@@ -447,10 +459,10 @@ pub struct C.UNICODE_STRING_WOW64 {
 // it to find the process environment block of a process.
 [typedef]
 pub struct C.PROCESS_BASIC_INFORMATION {
-	ExitStatus C.NTSTATUS
+	ExitStatus NTSTATUS
 	PebBaseAddress &C.PEB = unsafe { nil }
 	AffinityMask PULONG
-	BasePriority C.KPRIORITY
+	BasePriority KPRIORITY
 	UniqueProcessId PULONG
 	InheritedFromUniqueProcessId PULONG
 }
@@ -459,10 +471,10 @@ pub struct C.PROCESS_BASIC_INFORMATION {
 // it to find the process environment block of a x64 process when running as x32.
 [typedef]
 pub struct C.PROCESS_BASIC_INFORMATION_WOW64 {
-	ExitStatus C.NTSTATUS
+	ExitStatus NTSTATUS
 	PebBaseAddress u64
 	AffinityMask u64
-	BasePriority C.KPRIORITY
+	BasePriority KPRIORITY
 	UniqueProcessId u64
 	InheritedFromUniqueProcessId u64
 }

--- a/win/interop.v
+++ b/win/interop.v
@@ -166,6 +166,14 @@ pub struct C.RGBQUAD {
 	rgbReserved	BYTE
 }
 
+// C.RGBQUAD represents the well known COMM_FAULT_OFFSETS struct from widows.
+// In rpv it is not used, but definition is required for C interop.
+[typedef]
+pub struct C.COMM_FAULT_OFFSETS {
+	CommOffset	u16
+	FaultOffset u16
+}
+
 // C.GUID represents the well known GUID struct from widows. In rpv,
 // it is used for different purposes. Mainly to identify RPC interfaces,
 // that all contain GUIDs as part of their internal definition.

--- a/win/interop.v
+++ b/win/interop.v
@@ -716,22 +716,21 @@ pub struct C.BITMAPFILEHEADER {
 	bfOffBits DWORD
 }
 
-// C.SYSTEM_INFO contains information on the currently operating system
+// SYSTEM_INFO contains information on the currently operating system
 // and the underlying hardware. rpv uses it, to obtain the process
 // architecture.
-[typedef]
-pub struct C.SYSTEM_INFO {
-	wProcessorArchitecture WORD
-	wReserved WORD
-	dwPageSize DWORD
-	lpMinimumApplicationAddress LPVOID
-	lpMaximumApplicationAddress LPVOID
-	dwActiveProcessorMask &DWORD = unsafe { nil }
-	dwNumberOfProcessors DWORD
-	dwProcessorType DWORD
-	dwAllocationGranularity DWORD
-	wProcessorLevel WORD
-	wProcessorRevision WORD
+pub struct SYSTEM_INFO {
+	processor_architecture WORD
+	reserved WORD
+	page_size DWORD
+	minimum_application_address LPVOID
+	maximum_application_address LPVOID
+	active_processor_mask &DWORD = unsafe { nil }
+	number_of_processors DWORD
+	processor_type DWORD
+	allocation_granularity DWORD
+	processor_level WORD
+	processor_revision WORD
 }
 
 pub const (
@@ -1730,11 +1729,11 @@ pub fn icon_to_bmp(icon HANDLE)! string
 pub fn get_process_arch(process_handle HANDLE)! Arch
 {
 	mut wow64 := false
-	system_info := C.SYSTEM_INFO{}
+	system_info := SYSTEM_INFO{}
 
 	C.GetNativeSystemInfo(&system_info)
 
-	if system_info.wProcessorArchitecture == C.PROCESSOR_ARCHITECTURE_INTEL
+	if system_info.processor_architecture == C.PROCESSOR_ARCHITECTURE_INTEL
 	{
 		return Arch.x86
 	}
@@ -1897,7 +1896,7 @@ fn C.GetLastError() DWORD
 fn C.GetLogicalDrives() DWORD
 fn C.GetMappedFileNameA(process_handle HANDLE, addr LPVOID, filename &char, size DWORD) DWORD
 fn C.GetModuleFileNameExA(process_handle HANDLE, module_handle_array HANDLE, filename LPSTR, size DWORD) DWORD
-fn C.GetNativeSystemInfo(system_info &C.SYSTEM_INFO)
+fn C.GetNativeSystemInfo(system_info &SYSTEM_INFO)
 fn C.GetObject(h HANDLE, c int, pv LPVOID) int
 fn C.GetProcessId(process_handle HANDLE) DWORD
 fn C.GetSystemDirectoryA(buffer LPSTR, size UINT) UINT

--- a/win/interop.v
+++ b/win/interop.v
@@ -158,7 +158,7 @@ pub struct PS_PROTECTION {
 
 // C.RGBQUAD represents the well known RGBQUAD struct from widows. In rpv
 // it is not used, but definition is required for C interop.
-[typedef]
+@[typedef]
 pub struct C.RGBQUAD {
 	rgbBlue		BYTE
 	rgbGreen	BYTE
@@ -168,7 +168,7 @@ pub struct C.RGBQUAD {
 
 // C.RGBQUAD represents the well known COMM_FAULT_OFFSETS struct from widows.
 // In rpv it is not used, but definition is required for C interop.
-[typedef]
+@[typedef]
 pub struct C.COMM_FAULT_OFFSETS {
 	CommOffset	u16
 	FaultOffset u16
@@ -177,7 +177,7 @@ pub struct C.COMM_FAULT_OFFSETS {
 // C.GUID represents the well known GUID struct from widows. In rpv,
 // it is used for different purposes. Mainly to identify RPC interfaces,
 // that all contain GUIDs as part of their internal definition.
-[typedef]
+@[typedef]
 pub struct C.GUID {
 	Data1 u32
 	Data2 u16
@@ -208,7 +208,7 @@ pub fn (this C.GUID) equals(other C.GUID) bool
 // C.IMAGE_DOS_HEADER is a well known header that can be found in PE files.
 // rpv is especially interested in the e_lfanew member, as this contains the
 // offset to the C.IMAGE_NT_HEADERS.
-[typedef]
+@[typedef]
 pub struct C.IMAGE_DOS_HEADER {
 	e_magic WORD
 	e_cblp WORD
@@ -252,7 +252,7 @@ pub struct IMAGE_SECTION_HEADER {
 // C.IMAGE_NT_HEADERS represents the PE header format. rpv uses it to determine
 // the architecture the PE was compiled for and to locate the different sections
 // within the PE file.
-[typedef]
+@[typedef]
 pub struct C.IMAGE_NT_HEADERS {
 	Signature DWORD
 	FileHeader C.IMAGE_FILE_HEADER
@@ -261,7 +261,7 @@ pub struct C.IMAGE_NT_HEADERS {
 
 // C.IMAGE_OPTIONAL_HEADER is actually not used by rpv and is only defined to
 // complete the C.IMAGE_NT_HEADERS struct definition.
-[typedef]
+@[typedef]
 pub struct C.IMAGE_OPTIONAL_HEADER {
 	Magic WORD
 	MajorLinkerVersion BYTE
@@ -299,7 +299,7 @@ pub struct C.IMAGE_OPTIONAL_HEADER {
 // C.IMAGE_NT_HEADERS32 represents the PE header format. rpv uses it to determine
 // the architecture the PE was compiled for and to locate the different sections
 // within the PE file.
-[typedef]
+@[typedef]
 pub struct C.IMAGE_NT_HEADERS32 {
 	Signature DWORD
 	FileHeader C.IMAGE_FILE_HEADER
@@ -308,7 +308,7 @@ pub struct C.IMAGE_NT_HEADERS32 {
 
 // C.IMAGE_OPTIONAL_HEADER32 is actually not used by rpv and is only defined to
 // complete the C.IMAGE_NT_HEADERS32 struct definition.
-[typedef]
+@[typedef]
 pub struct C.IMAGE_OPTIONAL_HEADER32 {
 	Magic WORD
 	MajorLinkerVersion BYTE
@@ -345,7 +345,7 @@ pub struct C.IMAGE_OPTIONAL_HEADER32 {
 
 // C.IMAGE_DATA_DIRECTORY represents a data directory. This struct is actually
 // not used by rpv, but defined to complete the C.IMAGE_OPTIONAL_HEADER struct.
-[typedf]
+@[typedf]
 pub struct C.IMAGE_DATA_DIRECTORY
 {
 	VirtualAddress DWORD
@@ -355,7 +355,7 @@ pub struct C.IMAGE_DATA_DIRECTORY
 // C.IMAGE_FILE_HEADER represents the COFF header and is used by rpv to
 // obtain the architecture the PE was compiled for and the number of it's
 // contained sections.
-[typedef]
+@[typedef]
 pub struct C.IMAGE_FILE_HEADER {
 	Machine WORD
 	NumberOfSections WORD
@@ -379,7 +379,7 @@ pub struct ModuleSectionInfo{
 
 // C.SHFILEINFOA contains information on a file object. rpv uses this struct
 // to obtain a handle to the icon of a file.
-[typedef]
+@[typedef]
 pub struct C.SHFILEINFOA {
 	hIcon	voidptr
 	iIcon int
@@ -390,7 +390,7 @@ pub struct C.SHFILEINFOA {
 
 // C.PEB is the well known process environment block struct. rpv uses it to
 // to obtain the cmdline a process was started with.
-[typedef]
+@[typedef]
 pub struct C.PEB {
 	Reserved1 [2]BYTE
 	BeingDebugged BYTE
@@ -416,7 +416,7 @@ pub struct C.PEB {
 // C.PEB64 is the well known process environment block struct. rpv uses it to
 // to obtain the cmdline a process was started with. Not all fields of the
 // struct were defined, as access is only required to the first few fields.
-[typedef]
+@[typedef]
 pub struct C.PEB64 {
 	Reserved1 [4]BYTE
 	Reserved2 [2]u64
@@ -426,7 +426,7 @@ pub struct C.PEB64 {
 
 // C.RTL_USER_PROCESS_PARAMETERS is contained within the PEB structures and
 // can be used to retrieve the cmdline of a process.
-[typedef]
+@[typedef]
 pub struct C.RTL_USER_PROCESS_PARAMETERS {
 	Reserved1 [16]BYTE
 	Reserved2 [10]PVOID
@@ -437,7 +437,7 @@ pub struct C.RTL_USER_PROCESS_PARAMETERS {
 // C.RTL_USER_PROCESS_PARAMETERS_WOW64 is contained within the PEB structures and
 // can be used to retrieve the cmdline of a process. This version of the struct
 // is required when accessing an x64 process from a x32 process.
-[typedef]
+@[typedef]
 pub struct C.RTL_USER_PROCESS_PARAMETERS_WOW64 {
 	Reserved1 [16]BYTE
 	Reserved2 [10]u64
@@ -446,7 +446,7 @@ pub struct C.RTL_USER_PROCESS_PARAMETERS_WOW64 {
 }
 
 // C.UNICODE_STRING is a well known struct to represent a unicode string.
-[typedef]
+@[typedef]
 pub struct C.UNICODE_STRING {
    Length USHORT
    MaximumLength USHORT
@@ -456,7 +456,7 @@ pub struct C.UNICODE_STRING {
 // C.UNICODE_STRING_WOW64 is a well known struct to represent a unicode string.
 // This version of the struct is required by C.RTL_USER_PROCESS_PARAMETERS_WOW64,
 // that is used when reading x64 command line arguments from a x32 process.
-[typedef]
+@[typedef]
 pub struct C.UNICODE_STRING_WOW64 {
    Length USHORT
    MaximumLength USHORT
@@ -465,7 +465,7 @@ pub struct C.UNICODE_STRING_WOW64 {
 
 // C.PROCESS_BASIC_INFORMATION is another well known Windows structure. rpv uses
 // it to find the process environment block of a process.
-[typedef]
+@[typedef]
 pub struct C.PROCESS_BASIC_INFORMATION {
 	ExitStatus NTSTATUS
 	PebBaseAddress &C.PEB = unsafe { nil }
@@ -477,7 +477,7 @@ pub struct C.PROCESS_BASIC_INFORMATION {
 
 // C.PROCESS_BASIC_INFORMATION_WOW64 is another well known Windows structure. rpv uses
 // it to find the process environment block of a x64 process when running as x32.
-[typedef]
+@[typedef]
 pub struct C.PROCESS_BASIC_INFORMATION_WOW64 {
 	ExitStatus NTSTATUS
 	PebBaseAddress u64
@@ -490,7 +490,7 @@ pub struct C.PROCESS_BASIC_INFORMATION_WOW64 {
 // C.LARGE_INTEGER represents a 64bit integer value. Module version information is
 // represented by this struct. The definition actually contains a union, which needs
 // to be expressed as plain struct members in v at the time of writing.
-[typedef]
+@[typedef]
 pub union C.LARGE_INTEGER {
 	mut:
 	LowPart DWORD
@@ -501,7 +501,7 @@ pub union C.LARGE_INTEGER {
 // C.LUID is described by Microsoft as local identifier. It is used when working
 // witch process privileges. rpv needs it, to enable debug privileges for the
 // current process.
-[typedef]
+@[typedef]
 pub struct C.LUID {
 	mut:
 	LowPart DWORD
@@ -510,7 +510,7 @@ pub struct C.LUID {
 
 // C.LUID_AND_ATTRIBUTES merges a C.LUID struct with it's associated attributes.
 // This struct is used within the C.TOKEN_PRIVILEGES struct.
-[typedef]
+@[typedef]
 pub struct C.LUID_AND_ATTRIBUTES {
 	mut:
 	  Luid C.LUID
@@ -518,7 +518,7 @@ pub struct C.LUID_AND_ATTRIBUTES {
 }
 
 // C.TOKEN_PRIVILEGES contains information on privileges that are held by a token.
-[typedef]
+@[typedef]
 pub struct C.TOKEN_PRIVILEGES {
 	mut:
 	PrivilegeCount DWORD
@@ -527,14 +527,14 @@ pub struct C.TOKEN_PRIVILEGES {
 
 // C.TOKEN_USER contains information on the user that is associated with an access
 // token.
-[typedef]
+@[typedef]
 pub struct C.TOKEN_USER {
 	User C.SID_AND_ATTRIBUTES
 }
 
 // C.SID_AND_ATTRIBUTES is contained in C.TOKEN_USER and is used to obtain
 // information on the user an access token is associated with.
-[typedef]
+@[typedef]
 pub struct C.SID_AND_ATTRIBUTES {
 	Sid PSID
 	Attributes DWORD
@@ -542,13 +542,13 @@ pub struct C.SID_AND_ATTRIBUTES {
 
 // C.SID is the well known security identifier structure. It is used to
 // identify groups and users.
-[typedef]
+@[typedef]
 pub struct C.SID {
 }
 
 // C.PROCESSENTRY32 is used when creating snapshots. It is one entry in the
 // list of processes, that were available when the snapshot was taken.
-[typedef]
+@[typedef]
 pub struct C.PROCESSENTRY32 {
 	dwSize DWORD
 	cntUsage DWORD
@@ -564,7 +564,7 @@ pub struct C.PROCESSENTRY32 {
 
 // C.MODULEENTRY32 is used when creating snapshots. It is one entry of a
 // module list from a process.
-[typedef]
+@[typedef]
 pub struct C.MODULEENTRY32 {
 	dwSize DWORD
 	th32ModuleID DWORD
@@ -580,7 +580,7 @@ pub struct C.MODULEENTRY32 {
 
 // C.VS_FIXEDFILEINFO contains version information of a file. rpv uses
 // this struct to obtain the module version of a file.
-[typedef]
+@[typedef]
 pub struct C.VS_FIXEDFILEINFO {
 	dwSignature DWORD
 	dwStrucVersion DWORD
@@ -599,7 +599,7 @@ pub struct C.VS_FIXEDFILEINFO {
 
 // C.SecPkgInfoA describes a security package. Security packages can be
 // associated with RPC servers and rpv uses this struct to determine this.
-[typedef]
+@[typedef]
 pub struct C.SecPkgInfoA {
 	fCapabilities u32
 	wVersion u16
@@ -611,7 +611,7 @@ pub struct C.SecPkgInfoA {
 
 // C.MEMORY_BASIC_INFORMATION contains information about a specific memory
 // region within the virtual address space.
-[typedef]
+@[typedef]
 pub struct C.MEMORY_BASIC_INFORMATION {
 	BaseAddress PVOID
 	AllocationBase PVOID
@@ -657,7 +657,7 @@ pub struct LocationInfo {
 }
 
 // C.ICONINFO contains icon information.
-[typedef]
+@[typedef]
 pub struct C.ICONINFO {
 	fIcon bool
 	xHotspot u32
@@ -668,7 +668,7 @@ pub struct C.ICONINFO {
 
 // C.BITMAP describes an array of bytes that forms an icon. When processing
 // file system icons, this type is used to encode the icons.
-[typedef]
+@[typedef]
 pub struct C.BITMAP {
 	mut:
 	bmType int
@@ -714,7 +714,7 @@ pub struct BITMAPV4INFOHEADER {
 }
 
 // BITMAPFILEHEADER describes the first few bytes of a bitmap file.
-[typedef]
+@[typedef]
 pub struct C.BITMAPFILEHEADER {
 	mut:
 	bfType WORD

--- a/win/pdb.v
+++ b/win/pdb.v
@@ -15,7 +15,7 @@ struct CV_INFO_PDB70{
 
 // C.IMAGE_DEBUG_DIRECTORY contains the formatting of the debug
 // directory of an executable.
-[typedef]
+@[typedef]
 struct C.IMAGE_DEBUG_DIRECTORY {
   Characteristics DWORD
   TimeDateStamp DWORD


### PR DESCRIPTION
### Added

* Add offset property to `RpcMethod`
* Add offset property to `SecurityCallback`

### Changed

* Fix type errors caused by newer v versions
* Fix incorrect attr syntax in newer v versions
* Fix incorrect address of security callbacks
* Rename `base` property of `RpcMethod` to `addr`
* Rename `base` property of `SecurityCallback` to `addr`