### PR TITLE
Prepare v1.2.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## v1.2.0 - July 29, 2024
+
+### Added
+
+* Add RPC interface version information to `RpcInterfaceInfo`
+* Add support for loading PDB symbols of method parameters (not in use yet)
+
+### Changed
+
+* Fix incorrect module locations for modules with uppercase filenames
+
+
 ## v1.1.1 - July 19, 2024
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![](https://github.com/qtc-de/rpv/actions/workflows/build-examples.yml/badge.svg?branch=main)](https://github.com/qtc-de/rpv/actions/workflows/build-examples.yml)
 [![](https://github.com/qtc-de/rpv/actions/workflows/build-examples.yml/badge.svg?branch=dev)](https://github.com/qtc-de/rpv/actions/workflows/build-examples.yml)
-[![](https://img.shields.io/badge/version-1.1.1-blue)](https://github.com/qtc-de/rpv/releases)
+[![](https://img.shields.io/badge/version-1.2.0-blue)](https://github.com/qtc-de/rpv/releases)
 [![](https://img.shields.io/badge/programming%20language-v-blue)](https://vlang.io/)
 [![](https://img.shields.io/badge/license-GPL%20v3.0-blue)](https://github.com/qtc-de/rpv/blob/master/LICENSE)
 [![](https://img.shields.io/badge/docs-fa6b05)](https://qtc-de.github.io/rpv)

--- a/src/midl.v
+++ b/src/midl.v
@@ -156,9 +156,6 @@ pub fn (intf RpcInterfaceInfo) decode_methods(pid u32, methods []int)! MidlInter
 	types.sort(a.id < b.id)
 
 	mut name := intf.name
-	v_major := intf.intf.server_interface.interface_id.VersMajor
-	v_minor := intf.intf.server_interface.interface_id.VersMinor
-
 	if name == ''
 	{
 		name = '${intf.id}'
@@ -167,7 +164,7 @@ pub fn (intf RpcInterfaceInfo) decode_methods(pid u32, methods []int)! MidlInter
 	return MidlInterface {
 		id: '${intf.id}'
 		name: name.replace('-', '')
-		version: '${v_major}.${v_minor}'
+		version: intf.version
 		types: types
 		functions: functions
 	}

--- a/src/rpc.v
+++ b/src/rpc.v
@@ -58,6 +58,7 @@ pub struct RpcInterfaceInfo {
 	dispatch_table_addr voidptr
 	location win.LocationInfo
 	id string
+	version string
 	annotation string
 	ep_registered bool
 	intf RpcInterface
@@ -695,6 +696,7 @@ pub fn (interface_info RpcInterfaceBasicInfo) enrich_h(process_handle win.HANDLE
 	return RpcInterfaceInfo {
 		base: interface_info.base
 		id: win.uuid_to_str(interface_info.intf.server_interface.interface_id) or { 'unknown' }
+		version: win.get_interface_version(interface_info.intf.server_interface.interface_id)
 		intf: interface_info.intf
 		typ: interface_info.typ
 		dispatch_table_addr: dispatch_table.DispatchTable

--- a/src/rpc.v
+++ b/src/rpc.v
@@ -319,6 +319,9 @@ pub fn (mut pi RpvProcessInformation) update(mut resolver SymbolResolver)!
 			for mut method in intf_info.methods
 			{
 				method.name = resolver.load_symbol(intf_info.location.path, method.addr) or { method.name }
+
+				// TODO
+				resolver.load_symbols(intf_info.location.path, method.addr)
 			}
 
 			if intf_info.sec_callback.addr != &voidptr(0)
@@ -647,6 +650,9 @@ pub fn (interface_info RpcInterfaceBasicInfo) enrich_h(process_handle win.HANDLE
 		{
 			base := win.read_proc_mem_s[usize](process_handle, unsafe { midl_server_info.DispatchTable + ctr }) or { break }
 			fmt := win.read_proc_mem_s[u16](process_handle, unsafe { &u16(midl_server_info.FmtStringOffset) + ctr }) or { break }
+
+			// TODO
+			resolver.load_symbols(location_info.path, u64(base))
 
 			unsafe {
 				rpc_methods << RpcMethod {

--- a/src/rpc.v
+++ b/src/rpc.v
@@ -319,6 +319,12 @@ pub fn (mut pi RpvProcessInformation) update(mut resolver SymbolResolver)!
 
 			for mut method in intf_info.methods
 			{
+				/*
+				 * The method.symbols property was supposed to hold symbol data for function parameters
+				 * that is displayed during midl decompilation. However, at the time of writing, it seems
+				 * that only combase.dll contains such symbols, unless the retrieval logic is wrong.
+				 * Therefore, the symbol information is currently not further used, but might be in future.
+				 */
 				method.name = resolver.load_symbol(intf_info.location.path, method.addr) or { method.name }
 				method.symbols = resolver.load_symbols(intf_info.location.path, method.addr) or { []string{} }
 			}
@@ -650,6 +656,12 @@ pub fn (interface_info RpcInterfaceBasicInfo) enrich_h(process_handle win.HANDLE
 			base := win.read_proc_mem_s[usize](process_handle, unsafe { midl_server_info.DispatchTable + ctr }) or { break }
 			fmt := win.read_proc_mem_s[u16](process_handle, unsafe { &u16(midl_server_info.FmtStringOffset) + ctr }) or { break }
 
+			/*
+			 * The method.symbols property was supposed to hold symbol data for function parameters
+			 * that is displayed during midl decompilation. However, at the time of writing, it seems
+			 * that only combase.dll contains such symbols, unless the retrieval logic is wrong.
+			 * Therefore, the symbol information is currently not further used, but might be in future.
+			 */
 			name := resolver.load_symbol(location_info.path, u64(base)) or { 'Proc${ctr}' }
 			symbols := resolver.load_symbols(location_info.path, u64(base)) or { []string{} }
 

--- a/src/symbol-resolver.v
+++ b/src/symbol-resolver.v
@@ -134,6 +134,19 @@ pub fn (resolver SymbolResolver) load_symbol(location string, offset u64)? strin
 	return none
 }
 
+// load_symbols attempts to resolve the location + offset information to a symbol
+// name. If successful, the symbol name is returned. If the symbol cannot be found
+// the function returns none.
+pub fn (resolver SymbolResolver) load_symbols(location string, offset u64)? []string
+{
+	if resolver.has_pdb
+	{
+		return resolver.pdb_resolver.load_symbols(offset) or { return none }
+	}
+
+	return none
+}
+
 // load_uuid attempts to resolve an interface name by looking up it's uuid.
 // The function call is always successful. If the interface uuid is not found
 // within the SymbolResolver, the uuid itself is returned.

--- a/src/symbol-resolver.v
+++ b/src/symbol-resolver.v
@@ -4,22 +4,6 @@ import os
 import win
 import toml
 
-// SymbolResolver is used to resolve method and interface names during runtime.
-// SymbolResolver uses a hybrid approach with PDB files and a custom rpv symbol
-// file in toml format to resolve symbols. Apart from symbols, SymbolResolver
-// can also track notes that were taken for RPC interfaces or methods.
-pub struct SymbolResolver {
-	mut:
-	symbols map[string][]Symbol
-	params map[string][]SymbolSet
-	uuids map[string]InterfaceData
-	has_pdb bool
-	pdb_resolver win.PdbResolver
-	pub mut:
-	symbol_file string
-	symbol_path string
-}
-
 // Symbol represents a single symbol. It contains the offset of the symbol and
 // it's associated name.
 struct Symbol {
@@ -28,12 +12,75 @@ struct Symbol {
 	offset u64
 }
 
+
 // SymbolSet represents a set of symbols like method parameter names.
 struct SymbolSet {
 	mut:
 	names []string
 	offset u64
 }
+
+// SymbolMap maps a location (usually a dll file on the file system)
+// to symbols that are already known for this location.
+type SymbolMap = map[string][]Symbol
+
+// lookup checks whether a symbol is already known for the specified
+// offset + location combination
+fn (sym_map SymbolMap) lookup(location string, offset u64)? string
+{
+	if location in sym_map
+	{
+		for symbol in sym_map[location]
+		{
+			if symbol.offset == offset
+			{
+				return symbol.name
+			}
+		}
+	}
+
+	return none
+}
+
+// SymbolSetMap maps a location (usually a dll file on the file system)
+// to symbols that are already known for this location.
+type SymbolSetMap = map[string][]SymbolSet
+
+// lookup checks whether a symbol is already known for the specified
+// offset + location combination
+fn (sym_map SymbolSetMap) lookup(location string, offset u64)? []string
+{
+	if location in sym_map
+	{
+		for symbol_set in sym_map[location]
+		{
+			if symbol_set.offset == offset
+			{
+				return symbol_set.names
+			}
+		}
+	}
+
+	return none
+}
+
+// SymbolResolver is used to resolve method and interface names during runtime.
+// SymbolResolver uses a hybrid approach with PDB files and a custom rpv symbol
+// file in toml format to resolve symbols. Apart from symbols, SymbolResolver
+// can also track notes that were taken for RPC interfaces or methods.
+pub struct SymbolResolver {
+	mut:
+	symbols SymbolMap
+	sym_cache SymbolMap
+	param_cache SymbolSetMap
+	uuids map[string]InterfaceData
+	has_pdb bool
+	pdb_resolver win.PdbResolver
+	pub mut:
+	symbol_file string
+	symbol_path string
+}
+
 
 // InterfaceData is used to associate names with RPC interfaces. Moreover, the struct
 // contains notes for the interface itself and for associated RPC methods.
@@ -121,48 +168,51 @@ pub fn parse_resolver(toml_data toml.Doc, pdb_path string, symbol_file string) S
 // load_symbol attempts to resolve the location + offset information to a symbol
 // name. If successful, the symbol name is returned. If the symbol cannot be found
 // the function returns none.
-pub fn (resolver SymbolResolver) load_symbol(location string, offset u64)? string
+pub fn (mut resolver SymbolResolver) load_symbol(location string, offset u64)? string
 {
-	if location in resolver.symbols
+	return resolver.symbols.lookup(location, offset) or
 	{
-		for symbol in resolver.symbols[location]
+		return resolver.sym_cache.lookup(location, offset) or
 		{
-			if symbol.offset == offset
+			if resolver.has_pdb
 			{
-				return symbol.name
+				if symbol := resolver.pdb_resolver.load_symbol(offset)
+				{
+					resolver.sym_cache[location] << Symbol {
+						name: symbol
+						offset: offset
+					}
+
+					return symbol
+				}
 			}
+
+			return none
 		}
 	}
-
-	if resolver.has_pdb
-	{
-		return resolver.pdb_resolver.load_symbol(offset) or { return none }
-	}
-
-	return none
 }
 
 // load_symbols attempts to resolve function parameter names from the specified location
-// and offset.
-pub fn (resolver SymbolResolver) load_symbols(location string, offset u64)? []string
+// and offset. Since some DLLs
+pub fn (mut resolver SymbolResolver) load_symbols(location string, offset u64)? []string
 {
-	if location in resolver.params
+	return resolver.param_cache.lookup(location, offset) or
 	{
-		for symbol_set in resolver.params[location]
+		if resolver.has_pdb
 		{
-			if symbol_set.offset == offset
+			if symbols := resolver.pdb_resolver.load_symbols(offset)
 			{
-				return symbol_set.names
+				resolver.param_cache[location] << SymbolSet {
+					names: symbols
+					offset: offset
+				}
+
+				return symbols
 			}
 		}
-	}
 
-	if resolver.has_pdb
-	{
-		return resolver.pdb_resolver.load_symbols(offset) or { return none }
+		return none
 	}
-
-	return none
 }
 
 // load_uuid attempts to resolve an interface name by looking up it's uuid.

--- a/v.mod
+++ b/v.mod
@@ -2,7 +2,7 @@ Module
 {
     name: 'rpv'
     author: 'Tobias Neitzel (@qtc_de)'
-    version: '1.1.1'
+    version: '1.2.0'
     repo_url: 'https://github.com/qtc-de/rpv'
     vcs: 'git'
     tags: ['rpc', 'rpv', 'rpv-web', 'rpcview']

--- a/win/interop.v
+++ b/win/interop.v
@@ -174,6 +174,20 @@ pub struct C.COMM_FAULT_OFFSETS {
 	FaultOffset u16
 }
 
+@[typedef]
+pub struct C.IMAGEHLP_STACK_FRAME {
+  InstructionOffset  ULONG64
+  ReturnOffset		 ULONG64
+  FrameOffset		 ULONG64
+  StackOffset		 ULONG64
+  BackingStoreOffset ULONG64
+  FuncTableEntry	 ULONG64
+  Params[4]			 ULONG64
+  Reserved[5]		 ULONG64
+  Virtual			 BOOL
+  Reserved2			 ULONG
+}
+
 // C.GUID represents the well known GUID struct from widows. In rpv,
 // it is used for different purposes. Mainly to identify RPC interfaces,
 // that all contain GUIDs as part of their internal definition.
@@ -1938,6 +1952,8 @@ fn C.SHGetFileInfoA(path &char, file_attrs DWORD, fileinfo &C.SHFILEINFOA, file_
 fn C.SymCleanup(process_handle HANDLE)
 fn C.SymFromAddr(process_handle HANDLE, address DWORD64, displacement &DWORD64, symbol &SymbolInfoV) bool
 fn C.SymEnumSymbolsForAddr(process_handle HANDLE, address DWORD64, callback fn(&SymbolInfoV, ULONG), context voidptr) bool
+fn C.SymEnumSymbols(process_handle HANDLE, base ULONG64, mask &char, callback fn(&SymbolInfoV, ULONG), context voidptr) bool
+fn C.SymSetContext(process_handle HANDLE, frame &C.IMAGEHLP_STACK_FRAME, context voidptr) bool
 fn C.SymInitialize(process_handle HANDLE, search_path &char, invade_process BOOL) bool
 fn C.SymLoadModuleEx(process_handle HANDLE, file_handle HANDLE, image PCSTR, mod PCSTR, dll_base u64, dll_size u32, data voidptr, flags u32) u64
 fn C.SymUnloadModule(process_handle HANDLE, module_base u32)

--- a/win/interop.v
+++ b/win/interop.v
@@ -1854,6 +1854,12 @@ pub fn uuid_to_str(interface_id C.RPC_IF_ID)! string
 	return unsafe { cstring_to_vstring(p_uuid_str) }
 }
 
+// get_interface_version returns the version of an RPC_IF_ID as string
+pub fn get_interface_version(interface_id C.RPC_IF_ID) string
+{
+	return '${interface_id.VersMajor}.${interface_id.VersMinor}'
+}
+
 // new_guid attempts to parse a C.GUID struct from the specified string.
 pub fn new_guid(guid_str string)! C.GUID
 {

--- a/win/interop.v
+++ b/win/interop.v
@@ -1642,7 +1642,7 @@ pub fn get_location_info_h(process_handle HANDLE, address voidptr)! LocationInfo
 
 		for
 		{
-			if unsafe { string_from_wide(module_entry.szModule) == location.substr(location.last_index('\\') or { 0 } + 1, location.len) }
+			if unsafe { string_from_wide(module_entry.szModule).to_lower() == location.substr(location.last_index('\\') or { 0 } + 1, location.len).to_lower() }
 			{
 				base_addr = module_entry.modBaseAddr
 				base_size = module_entry.modBaseSize

--- a/win/interop.v
+++ b/win/interop.v
@@ -1937,6 +1937,7 @@ fn C.RegQueryValueExA(key_handle HANDLE, value LPCSTR, resv &DWORD, reg_type &DW
 fn C.SHGetFileInfoA(path &char, file_attrs DWORD, fileinfo &C.SHFILEINFOA, file_info_size UINT, flags UINT) bool
 fn C.SymCleanup(process_handle HANDLE)
 fn C.SymFromAddr(process_handle HANDLE, address DWORD64, displacement &DWORD64, symbol &SymbolInfoV) bool
+fn C.SymEnumSymbolsForAddr(process_handle HANDLE, address DWORD64, callback fn(&SymbolInfoV, ULONG), context voidptr) bool
 fn C.SymInitialize(process_handle HANDLE, search_path &char, invade_process BOOL) bool
 fn C.SymLoadModuleEx(process_handle HANDLE, file_handle HANDLE, image PCSTR, mod PCSTR, dll_base u64, dll_size u32, data voidptr, flags u32) u64
 fn C.SymUnloadModule(process_handle HANDLE, module_base u32)


### PR DESCRIPTION
### Added

* Add RPC interface version information to `RpcInterfaceInfo`
* Add support for loading PDB symbols of method parameters (not in use yet)

### Changed

* Fix incorrect module locations for modules with uppercase filenames